### PR TITLE
Translate `RULES.md` to id-ID

### DIFF
--- a/profile/id/README.md
+++ b/profile/id/README.md
@@ -10,5 +10,5 @@ Kami juga bertekan untuk membantu dalam pengembangan dan memperkenalkan **[Gerak
 
 ### **Baca Menggunakan** [Bahasa Ambon](https://github.com/scc-ukim/.github/blob/main/profile/id/abs/README.md) atau [Bahasa Inggris](https://github.com/scc-ukim/.github/blob/main/profile/README.md)
 
-#### More: [Affiliation](https://github.com/scc-ukim/.github/blob/main/profile/AFFILIATION.md) | [Team](https://github.com/scc-ukim/.github/blob/main/profile/TEAM.md) | [Rules](https://github.com/scc-ukim/.github/blob/main/profile/RULES.md) | [Code of Conduct](https://github.com/scc-ukim/.github/blob/main/profile/id/CODE_OF_CONDUCT.md)
+#### More: [Affiliation](https://github.com/scc-ukim/.github/blob/main/profile/AFFILIATION.md) | [Team](https://github.com/scc-ukim/.github/blob/main/profile/TEAM.md) | [Aturan](https://github.com/scc-ukim/.github/blob/main/profile/id/RULES.md) | [Kode Etik](https://github.com/scc-ukim/.github/blob/main/profile/id/CODE_OF_CONDUCT.md)
 

--- a/profile/id/RULES.md
+++ b/profile/id/RULES.md
@@ -1,0 +1,15 @@
+## Aturan
+
+Sebagai sebuah organisasi tentu saja kami memiliki aturan tersendiri, dimana setiap anggota harus mematuhinya, segala jenis pelanggaran akan diatasi `secara internal` oleh kami dibawah pengawasan [Dekan Fakultas Ilmu Komputer](https://filkom.ukim.ac.id), tapi jika tingkat pelanggaran sudah melebih batas normal dan terus terjadi maka kami _tidak akan ragu-ragu mengambil tindakan hukum_.
+
+### Aturan berkaitan dengan repositories
+
+Dengan itu kami juga mempunyai beberapa aturan terkait dengan repositories:
+
+- Setiap tim harus menamakan repositori mereka mengikuti aturan:
+  - Setiap repositoru harus dimulai dengan kode tim (`wd` atau `ds`).
+  - Gunakan `-` untuk memisahkan kode tim dengan nama repositori.
+  - Penamaan repositori harus mengikuti `organisasi-namaproyek` contoh. `ukim-websitekampus`
+- Hanya tim dengan penamaan yang benar bisa melakukan `push` atau perubahan ke repositori yang terkait, atau kalian perlu izin dari ketua tim sebelum melakukan perubahan.
+- Semua proyek yang bersifat **`rahasia`** dilarang untuk dijadikan `publik` dan harus diatur sebagai `pribadi`.
+- `Disarankan untuk meng-fork repositori`, dari pada melakukan perubahan secara langsung ke repositori utama ([SCC's Repo](https://github.com/scc-ukim))


### PR DESCRIPTION
Translating `RULES.md` and fixes links to Localized `ID` in `id/README.md`